### PR TITLE
fix: Remove unrecognised category `Picker`

### DIFF
--- a/deepin-picker.desktop
+++ b/deepin-picker.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Categories=Graphics;Picker;
+Categories=Graphics;
 Comment=Color picker
 Exec=deepin-picker
 GenericName=Picker


### PR DESCRIPTION
desktop-file-validate failed to validate the desktop entry file:

error: value "Graphics;Picker;" for key "Categories" in group "Desktop Entry"
contains an unregistered value "Picker"; values extending the format should
start with "X-"

Log: Remove unrecognised category `Picker`
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>