### PR TITLE
fix: Fixed the issue where the clipboard may have no color value after absorbing color

### DIFF
--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -66,6 +66,8 @@ void Clipboard::copyToClipboard(QColor color, QString colorType)
     QClipboard *clipboard = QApplication::clipboard();
     clipboard->setText(colorString);
 
-    // Quit application.
-    QApplication::quit();
+    // Quit application. Delay exit by 100ms so that the color value can be stored in the clipboard normally
+    QTimer::singleShot(100, this,[=](){
+        QApplication::quit();
+    });
 }


### PR DESCRIPTION
   The color absorber delays exiting by 100ms so that the color values ​​can be stored in the clipboard normally.

Log: Fixed the issue where the clipboard may have no color value after absorbing color
Bug: https://pms.uniontech.com/bug-view-237007.html